### PR TITLE
Move .gitignore to root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs
+src/logs
 *.log
 npm-debug.log*
 yarn-debug.log*
@@ -7,15 +7,15 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
-node_modules
-dist
-dist-ssr
+src/node_modules
+src/dist
+src/dist-ssr
 *.local
 
 # Editor directories and files
-.vscode/*
-!.vscode/extensions.json
-.idea
+src/.vscode/*
+!src/.vscode/extensions.json
+src/.idea
 .DS_Store
 *.suo
 *.ntvs*


### PR DESCRIPTION
## Summary
- move `.gitignore` from `src/` to the project root
- adjust ignored paths to point to folders within `src`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861e99bb5a8832798ebc00687d7e250