### PR TITLE
Load words asynchronously

### DIFF
--- a/src/services/wordlist.ts
+++ b/src/services/wordlist.ts
@@ -1,4 +1,10 @@
-import words from '../utils/words.json';
+let cachedSet: Set<string> | null = null;
 
-const typedWords: string[] = words;
-export const wordSet = new Set<string>(typedWords);
+export const loadWordSet = async (): Promise<Set<string>> => {
+  if (cachedSet) {
+    return cachedSet;
+  }
+  const words: string[] = (await import('../utils/words.json')).default;
+  cachedSet = new Set<string>(words);
+  return cachedSet;
+};

--- a/src/services/wordlist.ts
+++ b/src/services/wordlist.ts
@@ -4,7 +4,12 @@ export const loadWordSet = async (): Promise<Set<string>> => {
   if (cachedSet) {
     return cachedSet;
   }
-  const words: string[] = (await import('../utils/words.json')).default;
-  cachedSet = new Set<string>(words);
-  return cachedSet;
+  try {
+    const words: string[] = (await import('../utils/words.json')).default;
+    cachedSet = new Set<string>(words);
+    return cachedSet;
+  } catch (error) {
+    console.error("Failed to load words.json:", error);
+    throw new Error("Could not load word set. Please check the words.json file.");
+  }
 };


### PR DESCRIPTION
## Summary
- make a helper to load words dynamically
- load the word list asynchronously in the game engine

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68620057d4b08327a7a55b8c8d0fbf75